### PR TITLE
exercise 11.16 Skipping a commit for tagging and deployment #skip

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,7 +9,7 @@ const PORT = process.env.PORT || 5001
 app.use(express.static('dist'))
 
 app.get('/version', (req, res) => {
-  res.send('10')
+  res.send('11')
 })
 
 app.get('/health', (req, res) => {


### PR DESCRIPTION
no versioning beta5 -> beta6
no version 11 for /version, stay version 11 for /version